### PR TITLE
Build & warning fixes on Linux

### DIFF
--- a/C/CD.c
+++ b/C/CD.c
@@ -24,6 +24,7 @@
 #include "CD.h"
 #include "RedBlackTree.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include "som/Vector.h"
 #include <assert.h>

--- a/C/Json.c
+++ b/C/Json.c
@@ -373,7 +373,7 @@ static JsonNumber* JsonNumber_create(const char* str)
     return me;
 }
 
-static const char JsonNumber_toString(JsonNumber* me) {
+static const char* JsonNumber_toString(JsonNumber* me) {
     return me->string;
 }
 
@@ -428,7 +428,7 @@ static JsonLiteral* JsonLiteral_create(const char* value)
     return me;
 }
 
-static const char JsonLiteral_toString(JsonLiteral* me) {
+static const char* JsonLiteral_toString(JsonLiteral* me) {
     return me->value;
 }
 
@@ -491,7 +491,7 @@ static void JsonPureStringParser_init(JsonPureStringParser* me, const char* stri
     me->current = 0;
 }
 
-static JsonPureStringParser_deinit(JsonPureStringParser* me)
+static void JsonPureStringParser_deinit(JsonPureStringParser* me)
 {
     if( me->captureBuffer.buf )
         free(me->captureBuffer.buf);
@@ -827,7 +827,7 @@ static bool verifyResult(Benchmark* me, int r)
     JsonValue* tmp = JsonObject_get(result->vtbl->asObject(result),"head");
     if (!tmp->vtbl->isObject(tmp))
         goto cleanup;
-    tmp = tmp = JsonObject_get(result->vtbl->asObject(result),"operations");
+    tmp = JsonObject_get(result->vtbl->asObject(result),"operations");
     if (!tmp->vtbl->isArray(tmp))
         goto cleanup;
     tmp = JsonObject_get(result->vtbl->asObject(result),"operations");

--- a/C/NBody.c
+++ b/C/NBody.c
@@ -198,10 +198,10 @@ static bool verifyResult2(double result, int innerIterations)
 {
     const double epsilon = 0.00000000000000005; // 5e-17
     if (innerIterations == 250000) {
-        return abs(result) - 0.1690859889909308 < epsilon;
+        return fabs(result) - 0.1690859889909308 < epsilon;
     }
     if (innerIterations == 1) {
-        return abs(result) - 0.16907495402506745 < epsilon;
+        return fabs(result) - 0.16907495402506745 < epsilon;
     }
 
     // Checkstyle: stop

--- a/C/RedBlackTree.c
+++ b/C/RedBlackTree.c
@@ -23,6 +23,7 @@
 
 #include "RedBlackTree.h"
 #include <stdbool.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <memory.h>
 

--- a/C/RedBlackTree.h
+++ b/C/RedBlackTree.h
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-#include <som/Interfaces.h>
+#include "som/Interfaces.h"
 
 typedef struct RedBlackTree RedBlackTree;
 

--- a/C/Run.h
+++ b/C/Run.h
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-#include <Benchmark.h>
+#include "Benchmark.h"
 #include <setjmp.h>
 
 typedef struct Run {

--- a/C/main.c
+++ b/C/main.c
@@ -21,6 +21,7 @@
 
 #include "Run.h"
 #include <assert.h>
+#include <stdio.h>
 #include "RedBlackTree.h"
 
 static int compare(const Bytes l, const Bytes r)

--- a/C/som/Vector.h
+++ b/C/som/Vector.h
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-#include <som/Interfaces.h>
+#include "Interfaces.h"
 
 typedef struct Vector Vector;
 


### PR DESCRIPTION
Tested with chibicc family, tcc and latest clang/gcc, `cc *.c som/*.c`  was used.

There are also too much of `-Wincompatible-pointer-types` I didn't bother to fix... these ones nasty because recent versions of gcc decided to hard error on em.  `cproc` also reject some of these.